### PR TITLE
fix: missing import for runtime config

### DIFF
--- a/src/runtime/server/api/callback.get.ts
+++ b/src/runtime/server/api/callback.get.ts
@@ -1,5 +1,6 @@
 import { defineEventHandler, getRequestURL, sendRedirect } from 'h3'
 import { getKindeClient } from '../utils/client'
+import { useRuntimeConfig } from '#imports'
 
 const config = useRuntimeConfig()
 


### PR DESCRIPTION
Nuxt doesn't auto import within node modules so set up import for `runtimeConfig`
