### PR TITLE
feat: expose the kinde client from the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,20 +81,19 @@ That's it! You can now use Nuxt Kinde in your Nuxt app ✨
 
 ### useAuth
 
-This returns the current auth state
+This returns the current auth state, with the following properties.
 
 #### loggedIn
 
-Returns a boolean depending if the user is logged in or not.
+A boolean that indicates if the user is logged in or not.
 
 #### user
 
-Returns the current logged in user state, returns null if the user is not logged in.
+The current logged in user state, or null if the user is not logged in.
 
+### useKindeClient
 
-### useKindeClient -
-
- **Server Only** returns the kinde client, see [Kinde SDK Documentation](https://kinde.com/docs/developer-tools/typescript-sdk/) for more details.
+**Server only**. This returns a Kinde client; see [Kinde SDK Documentation](https://kinde.com/docs/developer-tools/typescript-sdk/) for more details.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@ export default defineNuxtConfig({
 
 That's it! You can now use Nuxt Kinde in your Nuxt app ✨
 
+## Composables
+
+### useAuth
+
+This returns the current auth state
+
+#### loggedIn
+
+Returns a boolean depending if the user is logged in or not.
+
+#### user
+
+Returns the current logged in user state, returns null if the user is not logged in.
+
+
+### useKindeClient -
+
+ **Server Only** returns the kinde client, see [Kinde SDK Documentation](https://kinde.com/docs/developer-tools/typescript-sdk/) for more details.
+
 ## Development
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxtjs/kinde",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Nuxt integration for Kinde authentication",
   "repository": "nuxt-modules/kinde",
   "license": "MIT",
@@ -28,7 +28,7 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "@kinde-oss/kinde-typescript-sdk": "^2.2.1",
+    "@kinde-oss/kinde-typescript-sdk": "^2.3.1",
     "@nuxt/kit": "^3.8.0",
     "defu": "^6.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxtjs/kinde",
-  "version": "0.2.0",
+  "version": "0.1.4",
   "description": "Nuxt integration for Kinde authentication",
   "repository": "nuxt-modules/kinde",
   "license": "MIT",

--- a/playground/pages/dashboard.vue
+++ b/playground/pages/dashboard.vue
@@ -9,7 +9,11 @@
         <br>
         Build the important stuff.
       </p>
+      <p>
+        Logged in user permissions: {{ permissions }}
+      </p>
     </div>
+
     <section class="next-steps-section">
       <h2 class="text-heading-1">
         Next steps for you
@@ -22,4 +26,11 @@
 definePageMeta({
   middleware: ['auth-logged-in'],
 })
+
+const kinde = useKindeClient();
+
+const { data: permissions } = await useAsyncData(async () => {
+  return (await kinde.getPermissions())?.permissions;
+});
+
 </script>

--- a/playground/pages/dashboard.vue
+++ b/playground/pages/dashboard.vue
@@ -27,10 +27,11 @@ definePageMeta({
   middleware: ['auth-logged-in'],
 })
 
-const kinde = useKindeClient();
+const client = useKindeClient()
 
 const { data: permissions } = await useAsyncData(async () => {
-  return (await kinde.getPermissions())?.permissions;
+  const { permissions } = await client?.getPermissions() ?? {}
+  return permissions
 });
 
 </script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
   .:
     dependencies:
       '@kinde-oss/kinde-typescript-sdk':
-        specifier: ^2.2.1
+        specifier: ^2.3.1
         version: 2.3.2
       '@nuxt/kit':
         specifier: ^3.8.0
@@ -66,10 +66,10 @@ importers:
         version: 3.8.2(@types/node@20.10.1)(eslint@8.55.0)(rollup@3.29.4)(typescript@5.3.2)(vite@5.0.5)
       vue:
         specifier: latest
-        version: 3.3.10(typescript@5.3.2)
+        version: 3.3.9(typescript@5.3.2)
       vue-router:
         specifier: latest
-        version: 4.2.5(vue@3.3.10)
+        version: 4.2.5(vue@3.3.9)
 
 packages:
 
@@ -1486,6 +1486,7 @@ packages:
     dependencies:
       is-glob: 4.0.3
       micromatch: 4.0.5
+      napi-wasm: 1.1.0
     dev: true
     bundledDependencies:
       - napi-wasm
@@ -2281,11 +2282,27 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
+  /@vue/compiler-core@3.3.9:
+    resolution: {integrity: sha512-+/Lf68Vr/nFBA6ol4xOtJrW+BQWv3QWKfRwGSm70jtXwfhZNF4R/eRgyVJYoxFRhdCTk/F6g99BP0ffPgZihfQ==}
+    dependencies:
+      '@babel/parser': 7.23.5
+      '@vue/shared': 3.3.9
+      estree-walker: 2.0.2
+      source-map-js: 1.0.2
+    dev: true
+
   /@vue/compiler-dom@3.3.10:
     resolution: {integrity: sha512-NCrqF5fm10GXZIK0GrEAauBqdy+F2LZRt3yNHzrYjpYBuRssQbuPLtSnSNjyR9luHKkWSH8we5LMB3g+4z2HvA==}
     dependencies:
       '@vue/compiler-core': 3.3.10
       '@vue/shared': 3.3.10
+    dev: true
+
+  /@vue/compiler-dom@3.3.9:
+    resolution: {integrity: sha512-nfWubTtLXuT4iBeDSZ5J3m218MjOy42Vp2pmKVuBKo2/BLcrFUX8nCSr/bKRFiJ32R8qbdnnnBgRn9AdU5v0Sg==}
+    dependencies:
+      '@vue/compiler-core': 3.3.9
+      '@vue/shared': 3.3.9
     dev: true
 
   /@vue/compiler-sfc@3.3.10:
@@ -2303,11 +2320,33 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
+  /@vue/compiler-sfc@3.3.9:
+    resolution: {integrity: sha512-wy0CNc8z4ihoDzjASCOCsQuzW0A/HP27+0MDSSICMjVIFzk/rFViezkR3dzH+miS2NDEz8ywMdbjO5ylhOLI2A==}
+    dependencies:
+      '@babel/parser': 7.23.5
+      '@vue/compiler-core': 3.3.9
+      '@vue/compiler-dom': 3.3.9
+      '@vue/compiler-ssr': 3.3.9
+      '@vue/reactivity-transform': 3.3.9
+      '@vue/shared': 3.3.9
+      estree-walker: 2.0.2
+      magic-string: 0.30.5
+      postcss: 8.4.32
+      source-map-js: 1.0.2
+    dev: true
+
   /@vue/compiler-ssr@3.3.10:
     resolution: {integrity: sha512-12iM4jA4GEbskwXMmPcskK5wImc2ohKm408+o9iox3tfN9qua8xL0THIZtoe9OJHnXP4eOWZpgCAAThEveNlqQ==}
     dependencies:
       '@vue/compiler-dom': 3.3.10
       '@vue/shared': 3.3.10
+    dev: true
+
+  /@vue/compiler-ssr@3.3.9:
+    resolution: {integrity: sha512-NO5oobAw78R0G4SODY5A502MGnDNiDjf6qvhn7zD7TJGc8XDeIEw4fg6JU705jZ/YhuokBKz0A5a/FL/XZU73g==}
+    dependencies:
+      '@vue/compiler-dom': 3.3.9
+      '@vue/shared': 3.3.9
     dev: true
 
   /@vue/devtools-api@6.5.1:
@@ -2324,10 +2363,26 @@ packages:
       magic-string: 0.30.5
     dev: true
 
+  /@vue/reactivity-transform@3.3.9:
+    resolution: {integrity: sha512-HnUFm7Ry6dFa4Lp63DAxTixUp8opMtQr6RxQCpDI1vlh12rkGIeYqMvJtK+IKyEfEOa2I9oCkD1mmsPdaGpdVg==}
+    dependencies:
+      '@babel/parser': 7.23.5
+      '@vue/compiler-core': 3.3.9
+      '@vue/shared': 3.3.9
+      estree-walker: 2.0.2
+      magic-string: 0.30.5
+    dev: true
+
   /@vue/reactivity@3.3.10:
     resolution: {integrity: sha512-H5Z7rOY/JLO+e5a6/FEXaQ1TMuOvY4LDVgT+/+HKubEAgs9qeeZ+NhADSeEtrNQeiKLDuzeKc8v0CUFpB6Pqgw==}
     dependencies:
       '@vue/shared': 3.3.10
+    dev: true
+
+  /@vue/reactivity@3.3.9:
+    resolution: {integrity: sha512-VmpIqlNp+aYDg2X0xQhJqHx9YguOmz2UxuUJDckBdQCNkipJvfk9yA75woLWElCa0Jtyec3lAAt49GO0izsphw==}
+    dependencies:
+      '@vue/shared': 3.3.9
     dev: true
 
   /@vue/runtime-core@3.3.10:
@@ -2337,11 +2392,26 @@ packages:
       '@vue/shared': 3.3.10
     dev: true
 
+  /@vue/runtime-core@3.3.9:
+    resolution: {integrity: sha512-xxaG9KvPm3GTRuM4ZyU8Tc+pMVzcu6eeoSRQJ9IE7NmCcClW6z4B3Ij6L4EDl80sxe/arTtQ6YmgiO4UZqRc+w==}
+    dependencies:
+      '@vue/reactivity': 3.3.9
+      '@vue/shared': 3.3.9
+    dev: true
+
   /@vue/runtime-dom@3.3.10:
     resolution: {integrity: sha512-c/jKb3ny05KJcYk0j1m7Wbhrxq7mZYr06GhKykDMNRRR9S+/dGT8KpHuNQjv3/8U4JshfkAk6TpecPD3B21Ijw==}
     dependencies:
       '@vue/runtime-core': 3.3.10
       '@vue/shared': 3.3.10
+      csstype: 3.1.2
+    dev: true
+
+  /@vue/runtime-dom@3.3.9:
+    resolution: {integrity: sha512-e7LIfcxYSWbV6BK1wQv9qJyxprC75EvSqF/kQKe6bdZEDNValzeRXEVgiX7AHI6hZ59HA4h7WT5CGvm69vzJTQ==}
+    dependencies:
+      '@vue/runtime-core': 3.3.9
+      '@vue/shared': 3.3.9
       csstype: 3.1.2
     dev: true
 
@@ -2355,8 +2425,22 @@ packages:
       vue: 3.3.10(typescript@5.3.2)
     dev: true
 
+  /@vue/server-renderer@3.3.9(vue@3.3.9):
+    resolution: {integrity: sha512-w0zT/s5l3Oa3ZjtLW88eO4uV6AQFqU8X5GOgzq7SkQQu6vVr+8tfm+OI2kDBplS/W/XgCBuFXiPw6T5EdwXP0A==}
+    peerDependencies:
+      vue: 3.3.9
+    dependencies:
+      '@vue/compiler-ssr': 3.3.9
+      '@vue/shared': 3.3.9
+      vue: 3.3.9(typescript@5.3.2)
+    dev: true
+
   /@vue/shared@3.3.10:
     resolution: {integrity: sha512-2y3Y2J1a3RhFa0WisHvACJR2ncvWiVHcP8t0Inxo+NKz+8RKO4ZV8eZgCxRgQoA6ITfV12L4E6POOL9HOU5nqw==}
+    dev: true
+
+  /@vue/shared@3.3.9:
+    resolution: {integrity: sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA==}
     dev: true
 
   /abbrev@1.1.1:
@@ -4706,6 +4790,10 @@ packages:
     resolution: {integrity: sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==}
     engines: {node: ^14 || ^16 || >=18}
     hasBin: true
+    dev: true
+
+  /napi-wasm@1.1.0:
+    resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
     dev: true
 
   /natural-compare@1.4.0:
@@ -7114,6 +7202,15 @@ packages:
       vue: 3.3.10(typescript@5.3.2)
     dev: true
 
+  /vue-router@4.2.5(vue@3.3.9):
+    resolution: {integrity: sha512-DIUpKcyg4+PTQKfFPX88UWhlagBEBEfJ5A8XDXRJLUnZOvcpMF8o/dnL90vpVkGaPbjvXazV/rC1qBKrZlFugw==}
+    peerDependencies:
+      vue: ^3.2.0
+    dependencies:
+      '@vue/devtools-api': 6.5.1
+      vue: 3.3.9(typescript@5.3.2)
+    dev: true
+
   /vue@3.3.10(typescript@5.3.2):
     resolution: {integrity: sha512-zg6SIXZdTBwiqCw/1p+m04VyHjLfwtjwz8N57sPaBhEex31ND0RYECVOC1YrRwMRmxFf5T1dabl6SGUbMKKuVw==}
     peerDependencies:
@@ -7127,6 +7224,22 @@ packages:
       '@vue/runtime-dom': 3.3.10
       '@vue/server-renderer': 3.3.10(vue@3.3.10)
       '@vue/shared': 3.3.10
+      typescript: 5.3.2
+    dev: true
+
+  /vue@3.3.9(typescript@5.3.2):
+    resolution: {integrity: sha512-sy5sLCTR8m6tvUk1/ijri3Yqzgpdsmxgj6n6yl7GXXCXqVbmW2RCXe9atE4cEI6Iv7L89v5f35fZRRr5dChP9w==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@vue/compiler-dom': 3.3.9
+      '@vue/compiler-sfc': 3.3.9
+      '@vue/runtime-dom': 3.3.9
+      '@vue/server-renderer': 3.3.9(vue@3.3.9)
+      '@vue/shared': 3.3.9
       typescript: 5.3.2
     dev: true
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -92,6 +92,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Composables
     addImports({ name: 'useAuth', as: 'useAuth', from: resolver.resolve('./runtime/composables') })
+    addImports({ name: 'useKindeClient', as: 'useKindeClient', from: resolver.resolve('./runtime/composables') })
 
     // Middleware
     if (options.middleware) {

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -1,7 +1,10 @@
-import { useNuxtApp } from '#imports'
+import { useNuxtApp, useRequestEvent } from '#imports'
 import type { AuthState } from './types'
 
 export const useAuth = () => {
   return useNuxtApp().$auth as AuthState
 }
 
+export const useKindeClient = () => {
+  return useRequestEvent()?.context.kinde || null
+}

--- a/src/runtime/server/middleware/kinde.ts
+++ b/src/runtime/server/middleware/kinde.ts
@@ -29,7 +29,7 @@ async function createSessionManager(event: H3Event): Promise<SessionManager> {
       const session = await getSession(event, config)
       return session.data[itemKey] || memorySession[itemKey]
     },
-    async setSessionItem(itemKey, itemValue) {
+    async setSessionItem(itemKey, itemValue:  string | any) {
       if (keysInCookie.includes(itemKey)) {
         await updateSession(event, config, {
           [itemKey]: itemValue,

--- a/src/runtime/server/middleware/kinde.ts
+++ b/src/runtime/server/middleware/kinde.ts
@@ -29,12 +29,15 @@ async function createSessionManager(event: H3Event): Promise<SessionManager> {
       const session = await getSession(event, config)
       return session.data[itemKey] || memorySession[itemKey]
     },
-    async setSessionItem(itemKey, itemValue:  string | any) {
+    async setSessionItem(itemKey, itemValue) {
       if (keysInCookie.includes(itemKey)) {
         await updateSession(event, config, {
           [itemKey]: itemValue,
         })
       } else {
+        if (typeof itemValue !== 'string') {
+          throw new TypeError(`${itemKey} must be a string.`)
+        }
         memorySession[itemKey] = itemValue
       }
     },


### PR DESCRIPTION
- adds a `useKindeClient` which holds the kinde TS SDK client
- adds to the playground dashboard output of the permissions for the logged in user
- updated readme with information about the useAuth and useKindeClient composables.
- Updated version to 0.2.0 as this updates the underlying Kinde TS SDK and adds functionality to made use of the kinde client.