### PR TITLE
fix: incorrect type checking

### DIFF
--- a/src/runtime/server/middleware/kinde.ts
+++ b/src/runtime/server/middleware/kinde.ts
@@ -19,7 +19,7 @@ export default defineEventHandler(async event => {
 async function createSessionManager(event: H3Event): Promise<SessionManager> {
   // TODO: improve memory session in future
   const keysInCookie = ['refresh_token', 'access_token', 'ac-state-key']
-  const memorySession: Record<(typeof keysInCookie)[number], string> = {}
+  const memorySession: Record<(typeof keysInCookie)[number], unknown> = {}
   const config = {
     name: 'kinde',
     password: 'slkdaslkdjfskldafjaslkdjfasldkfjsdf',
@@ -35,9 +35,6 @@ async function createSessionManager(event: H3Event): Promise<SessionManager> {
           [itemKey]: itemValue,
         })
       } else {
-        if (typeof itemValue !== 'string') {
-          throw new TypeError(`${itemKey} must be a string.`)
-        }
         memorySession[itemKey] = itemValue
       }
     },


### PR DESCRIPTION
Issue: 

https://github.com/nuxt-modules/kinde/issues/39

With the release of 0.1.5 additional type checking were added.  Issue with this check was that it mismatched the types handled by the Kinde TS SDK.

An exception was added with the type was not a string, but this is breaking the auth flow entirely. 

Solution:

Update the memorySession store to match the type of the Kinde TS SDK for `setSessionItem` so instead of using the type string, use unknown. (https://github.com/kinde-oss/kinde-typescript-sdk/blob/0239214067fb170336a8b845e4a89f1b6bc9c7aa/lib/sdk/session-managers/BrowserSessionManager.ts#L44)