### PR TITLE
fix: missing import

### DIFF
--- a/src/runtime/server/middleware/kinde.ts
+++ b/src/runtime/server/middleware/kinde.ts
@@ -4,7 +4,7 @@ import type { CookieSerializeOptions } from 'cookie-es'
 import { defineEventHandler } from 'h3'
 
 import { getKindeClient } from '../utils/client'
-import { getSession, updateSession, clearSession } from '#imports'
+import { getSession, updateSession, clearSession, useRuntimeConfig } from '#imports'
 
 export default defineEventHandler(async event => {
   const sessionManager = await createSessionManager(event)


### PR DESCRIPTION
Missing import from https://github.com/nuxt-modules/kinde/pull/59

@danielroe can this be merged and new release cut? latest release is broken.