### PR TITLE
fix: missing getQuery import

### DIFF
--- a/src/runtime/server/api/login.get.ts
+++ b/src/runtime/server/api/login.get.ts
@@ -1,4 +1,4 @@
-import { defineEventHandler, sendRedirect } from 'h3'
+import { defineEventHandler, sendRedirect, getQuery } from 'h3'
 import { getKindeClient } from '../utils/client'
 
 export default defineEventHandler(async event => {

--- a/src/runtime/server/api/register.get.ts
+++ b/src/runtime/server/api/register.get.ts
@@ -1,4 +1,4 @@
-import { defineEventHandler, sendRedirect } from 'h3'
+import { defineEventHandler, sendRedirect, getQuery } from 'h3'
 import { getKindeClient } from '../utils/client'
 
 export default defineEventHandler(async event => {


### PR DESCRIPTION
## Problem:

When accessing api/login and api/register endpoints the server would return a 500 error with the message getQuery is not defined.

## Solution:

Added the getQuery from h3 to the imports for both login.get.ts and register.get.ts file. 