### PR TITLE
deps: update kinde-typescript-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:types": "vue-tsc --noEmit && cd playground && vue-tsc --noEmit"
   },
   "dependencies": {
-    "@kinde-oss/kinde-typescript-sdk": "^2.6.2",
+    "@kinde-oss/kinde-typescript-sdk": "^2.7.1",
     "@nuxt/kit": "^3.10.3",
     "cookie-es": "^1.0.0",
     "defu": "^6.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
   .:
     dependencies:
       '@kinde-oss/kinde-typescript-sdk':
-        specifier: ^2.6.2
-        version: 2.6.2
+        specifier: ^2.7.1
+        version: 2.7.1
       '@nuxt/kit':
         specifier: ^3.10.3
         version: 3.10.3(rollup@3.29.4)
@@ -955,8 +955,8 @@ packages:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  /@kinde-oss/kinde-typescript-sdk@2.6.2:
-    resolution: {integrity: sha512-z46iSYFP9u2h7cfrDQ44yjKIeZ/8/49Q2d8VOdTrLM/3tR2cL4/dVfxuUXW3g564mDMNy/VEDy4iqJ0GYEoQEQ==}
+  /@kinde-oss/kinde-typescript-sdk@2.7.1:
+    resolution: {integrity: sha512-YIig6htu7MdlrZ3OJNkgzk1JFxiO29MJPfDZu9o/ohs7b/ZKBTKje4QTYG9tjX4ipE5KDONBFQs4YT8tHZU/UQ==}
     dependencies:
       jwt-decode: 4.0.0
       uncrypto: 0.1.3

--- a/src/runtime/server/api/health.get.ts
+++ b/src/runtime/server/api/health.get.ts
@@ -1,5 +1,6 @@
 import { defineEventHandler } from 'h3'
 import { useRuntimeConfig } from '#imports'
+import { validateClientSecret } from '@kinde-oss/kinde-typescript-sdk'
 
 export default defineEventHandler(() => {
   const { kinde } = useRuntimeConfig()
@@ -9,6 +10,6 @@ export default defineEventHandler(() => {
     postLoginRedirectURL: kinde.postLoginRedirectURL,
     logoutRedirectURL: kinde.logoutRedirectURL,
     clientID: kinde.clientId,
-    clientSecret: kinde.clientSecret.match('[a-z0-9]{50}') ? 'Set correctly' : 'Not set correctly',
+    clientSecret: validateClientSecret(kinde.clientSecret) ? 'Set correctly' : 'Not set correctly',
   };
 })

--- a/src/runtime/server/middleware/kinde.ts
+++ b/src/runtime/server/middleware/kinde.ts
@@ -4,7 +4,7 @@ import type { CookieSerializeOptions } from 'cookie-es'
 import { defineEventHandler } from 'h3'
 
 import { getKindeClient } from '../utils/client'
-import { getSession, updateSession, clearSession } from '#imports'
+import { getSession, updateSession, clearSession, useRuntimeConfig } from '#imports'
 
 export default defineEventHandler(async event => {
   const sessionManager = await createSessionManager(event)


### PR DESCRIPTION
This updates the kinde TS SDK and uses the utility method to validate the client secret instead of doing directly in the module