### PR TITLE
chore: run npm fix on `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "@nuxtjs/kinde",
   "version": "0.1.10",
   "description": "Nuxt integration for Kinde authentication",
-  "repository": "nuxt-modules/kinde",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nuxt-modules/kinde.git"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Publishing a package with the latest version of npm gives rise to the following error:

```
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "repository" was changed from a string to an object
npm WARN publish "repository.url" was normalized to "git+https://github.com/<repo>.git"
```

This PR (it isn't much, I know!) runs the command ...

See https://docs.npmjs.com/cli/v10/configuring-npm/package-json and specifically https://github.com/npm/cli/issues/7299#issuecomment-2010009355.