### PR TITLE
fix: add idtoken to the cookie list

### DIFF
--- a/src/runtime/server/middleware/kinde.ts
+++ b/src/runtime/server/middleware/kinde.ts
@@ -21,7 +21,7 @@ export default defineEventHandler(async (event) => {
 
 async function createSessionManager(event: H3Event): Promise<SessionManager> {
   // TODO: improve memory session in future
-  const keysInCookie = ['refresh_token', 'access_token', 'ac-state-key']
+  const keysInCookie = ['refresh_token', 'access_token', 'id_token', 'ac-state-key']
   const memorySession: Record<(typeof keysInCookie)[number], unknown> = {}
 
   const config = useRuntimeConfig(event)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt-modules/kinde/issues/123

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Problem: 

getUser() always returned undefined and in some instances threw exception.

Solution:

The `id_token` was not included in the cookies which resulted in user information not being available, this adds to the cookie key list


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
