### PR TITLE
feat: allow configuring internal api routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ export default defineNuxtConfig({
     // enable the debug `/api/health` endpoint
     // debug: true,
     // 
-    // Set custom apiRoutes in case you use any of the default routes for other purposes
-    // apiRoutes: {
+    // Set custom endpoints in case you use any of the default routes for other purposes
+    // endpoints: {
     //   callback: '/api/callback',
     //   login: '/api/login',
     //   register: '/api/register',

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ export default defineNuxtConfig({
     //
     // enable the debug `/api/health` endpoint
     // debug: true,
+    // 
+    // Set custom apiRoutes in case you use any of the default routes for other purposes
+    // apiRoutes: {
+    //   callback: '/api/callback',
+    //   login: '/api/login',
+    //   register: '/api/register',
+    //   health: '/api/health',
+    //   logout: '/api/logout'
+    // }
   }
 })
 ```

--- a/src/module.ts
+++ b/src/module.ts
@@ -13,7 +13,7 @@ export interface ModuleOptions {
   password: string
   cookie: Partial<CookieSerializeOptions>
   middleware?: boolean
-  apiRoutes?: {
+  endpoints?: {
     callback?: string
     login?: string
     logout?: string
@@ -52,7 +52,7 @@ export default defineNuxtModule<ModuleOptions>({
       secure: !nuxt.options.dev,
       httpOnly: true,
     },
-    apiRoutes: {
+    endpoints: {
       callback: '/api/callback',
       login: '/api/login',
       register: '/api/register',
@@ -85,7 +85,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     addTemplate({
       filename: 'kinde-routes.config.mjs',
-      getContents: () => `export default ${JSON.stringify(options.apiRoutes)}`,
+      getContents: () => `export default ${JSON.stringify(options.endpoints)}`,
     })
 
     // https://github.com/Atinux/nuxt-auth-utils/blob/main/src/module.ts#L71-L80
@@ -112,19 +112,19 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     addServerHandler({
-      route: options.apiRoutes!.callback!,
+      route: options.endpoints!.callback!,
       handler:
         options.handlers?.callback
         || resolver.resolve('./runtime/server/api/callback.get'),
     })
     addServerHandler({
-      route: options.apiRoutes!.login!,
+      route: options.endpoints!.login!,
       handler:
         options.handlers?.login
         || resolver.resolve('./runtime/server/api/login.get'),
     })
     addServerHandler({
-      route: options.apiRoutes!.register!,
+      route: options.endpoints!.register!,
       handler:
         options.handlers?.register
         || resolver.resolve('./runtime/server/api/register.get'),
@@ -132,7 +132,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     if (options.debug) {
       addServerHandler({
-        route: options.apiRoutes!.health!,
+        route: options.endpoints!.health!,
         handler:
           options.handlers?.health
           || resolver.resolve('./runtime/server/api/health.get'),
@@ -140,7 +140,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
 
     addServerHandler({
-      route: options.apiRoutes!.logout!,
+      route: options.endpoints!.logout!,
       handler:
         options.handlers?.logout
         || resolver.resolve('./runtime/server/api/logout.get'),

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { readFile, writeFile } from 'node:fs/promises'
 
-import { addServerHandler, defineNuxtModule, addPlugin, createResolver, addRouteMiddleware, addImports, addComponent } from '@nuxt/kit'
+import { addServerHandler, defineNuxtModule, addPlugin, createResolver, addRouteMiddleware, addImports, addComponent, addTemplate } from '@nuxt/kit'
 import { defu } from 'defu'
 import type { CookieSerializeOptions } from 'cookie-es'
 import { join } from 'pathe'
@@ -52,6 +52,13 @@ export default defineNuxtModule<ModuleOptions>({
       secure: !nuxt.options.dev,
       httpOnly: true,
     },
+    apiRoutes: {
+      callback: '/api/callback',
+      login: '/api/login',
+      register: '/api/register',
+      health: '/api/health',
+      logout: '/api/logout',
+    },
     middleware: true,
     authDomain: '',
     clientId: '',
@@ -72,16 +79,13 @@ export default defineNuxtModule<ModuleOptions>({
       redirectURL: options.redirectURL,
       logoutRedirectURL: options.logoutRedirectURL,
       postLoginRedirectURL: options.postLoginRedirectURL,
-      // TODO: Fix typing for apiRoutes. Currently it shows up as any, but it should be string | undefined
-      apiRoutes: {
-        callback: options.apiRoutes?.callback,
-        login: options.apiRoutes?.login,
-        register: options.apiRoutes?.register,
-        health: options.apiRoutes?.health,
-        logout: options.apiRoutes?.logout,
-      },
       clientSecret: options.clientSecret,
       audience: options.audience,
+    })
+
+    addTemplate({
+      filename: 'kinde-routes.config.mjs',
+      getContents: () => `export default ${JSON.stringify(options.apiRoutes)}`,
     })
 
     // https://github.com/Atinux/nuxt-auth-utils/blob/main/src/module.ts#L71-L80
@@ -108,19 +112,19 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     addServerHandler({
-      route: options.apiRoutes?.callback || '/api/callback',
+      route: options.apiRoutes!.callback!,
       handler:
         options.handlers?.callback
         || resolver.resolve('./runtime/server/api/callback.get'),
     })
     addServerHandler({
-      route: options.apiRoutes?.login || '/api/login',
+      route: options.apiRoutes!.login!,
       handler:
         options.handlers?.login
         || resolver.resolve('./runtime/server/api/login.get'),
     })
     addServerHandler({
-      route: options.apiRoutes?.register || '/api/register',
+      route: options.apiRoutes!.register!,
       handler:
         options.handlers?.register
         || resolver.resolve('./runtime/server/api/register.get'),
@@ -128,7 +132,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     if (options.debug) {
       addServerHandler({
-        route: options.apiRoutes?.health || '/api/health',
+        route: options.apiRoutes!.health!,
         handler:
           options.handlers?.health
           || resolver.resolve('./runtime/server/api/health.get'),
@@ -136,7 +140,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
 
     addServerHandler({
-      route: options.apiRoutes?.logout || '/api/logout',
+      route: options.apiRoutes!.logout!,
       handler:
         options.handlers?.logout
         || resolver.resolve('./runtime/server/api/logout.get'),

--- a/src/module.ts
+++ b/src/module.ts
@@ -13,6 +13,13 @@ export interface ModuleOptions {
   password: string
   cookie: Partial<CookieSerializeOptions>
   middleware?: boolean
+  apiRoutes?: {
+    callback?: string
+    login?: string
+    logout?: string
+    register?: string
+    health?: string
+  }
   handlers?: {
     callback?: string
     login?: string
@@ -65,6 +72,14 @@ export default defineNuxtModule<ModuleOptions>({
       redirectURL: options.redirectURL,
       logoutRedirectURL: options.logoutRedirectURL,
       postLoginRedirectURL: options.postLoginRedirectURL,
+      // TODO: Fix typing for apiRoutes. Currently it shows up as any, but it should be string | undefined
+      apiRoutes: {
+        callback: options.apiRoutes?.callback,
+        login: options.apiRoutes?.login,
+        register: options.apiRoutes?.register,
+        health: options.apiRoutes?.health,
+        logout: options.apiRoutes?.logout,
+      },
       clientSecret: options.clientSecret,
       audience: options.audience,
     })
@@ -93,19 +108,19 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     addServerHandler({
-      route: '/api/callback',
+      route: options.apiRoutes?.callback || '/api/callback',
       handler:
         options.handlers?.callback
         || resolver.resolve('./runtime/server/api/callback.get'),
     })
     addServerHandler({
-      route: '/api/login',
+      route: options.apiRoutes?.login || '/api/login',
       handler:
         options.handlers?.login
         || resolver.resolve('./runtime/server/api/login.get'),
     })
     addServerHandler({
-      route: '/api/register',
+      route: options.apiRoutes?.register || '/api/register',
       handler:
         options.handlers?.register
         || resolver.resolve('./runtime/server/api/register.get'),
@@ -113,7 +128,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     if (options.debug) {
       addServerHandler({
-        route: '/api/health',
+        route: options.apiRoutes?.health || '/api/health',
         handler:
           options.handlers?.health
           || resolver.resolve('./runtime/server/api/health.get'),
@@ -121,7 +136,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
 
     addServerHandler({
-      route: '/api/logout',
+      route: options.apiRoutes?.logout || '/api/logout',
       handler:
         options.handlers?.logout
         || resolver.resolve('./runtime/server/api/logout.get'),

--- a/src/runtime/components/LoginLink.vue
+++ b/src/runtime/components/LoginLink.vue
@@ -11,12 +11,12 @@
 import type { LoginURLOptions } from '@kinde-oss/kinde-typescript-sdk'
 import { computed } from 'vue'
 import { withQuery } from 'ufo'
-import apiRoutes from '#build/kinde-routes.config.mjs'
+import endpoints from '#build/kinde-routes.config.mjs'
 
 const props = defineProps<LoginURLOptions>()
 const href = computed(() => {
   const { authUrlParams, ..._authUrlParams } = props
-  return withQuery(apiRoutes.login, {
+  return withQuery(endpoints.login, {
     ...authUrlParams,
     ..._authUrlParams,
   })

--- a/src/runtime/components/LoginLink.vue
+++ b/src/runtime/components/LoginLink.vue
@@ -11,12 +11,12 @@
 import type { LoginURLOptions } from '@kinde-oss/kinde-typescript-sdk'
 import { computed } from 'vue'
 import { withQuery } from 'ufo'
-import { useRuntimeConfig } from '#app'
+import apiRoutes from '#build/kinde-routes.config.mjs'
 
 const props = defineProps<LoginURLOptions>()
 const href = computed(() => {
   const { authUrlParams, ..._authUrlParams } = props
-  return withQuery(useRuntimeConfig().kinde.apiRoutes.login || '/api/login', {
+  return withQuery(apiRoutes.login, {
     ...authUrlParams,
     ..._authUrlParams,
   })

--- a/src/runtime/components/LoginLink.vue
+++ b/src/runtime/components/LoginLink.vue
@@ -11,10 +11,14 @@
 import type { LoginURLOptions } from '@kinde-oss/kinde-typescript-sdk'
 import { computed } from 'vue'
 import { withQuery } from 'ufo'
+import { useRuntimeConfig } from '#app'
 
 const props = defineProps<LoginURLOptions>()
 const href = computed(() => {
   const { authUrlParams, ..._authUrlParams } = props
-  return withQuery('/api/login', { ...authUrlParams, ..._authUrlParams })
+  return withQuery(useRuntimeConfig().kinde.apiRoutes.login || '/api/login', {
+    ...authUrlParams,
+    ..._authUrlParams,
+  })
 })
 </script>

--- a/src/runtime/components/RegisterLink.vue
+++ b/src/runtime/components/RegisterLink.vue
@@ -11,10 +11,14 @@
 import type { AuthURLOptions } from '@kinde-oss/kinde-typescript-sdk'
 import { computed } from 'vue'
 import { withQuery } from 'ufo'
+import { useRuntimeConfig } from '#app'
 
 const props = defineProps<AuthURLOptions>()
 const href = computed(() => {
   const { authUrlParams, ..._authUrlParams } = props
-  return withQuery('/api/register', { ...authUrlParams, ..._authUrlParams })
+  return withQuery(useRuntimeConfig().kinde.apiRoutes.register || '/api/register', {
+    ...authUrlParams,
+    ..._authUrlParams,
+  })
 })
 </script>

--- a/src/runtime/components/RegisterLink.vue
+++ b/src/runtime/components/RegisterLink.vue
@@ -11,12 +11,12 @@
 import type { AuthURLOptions } from '@kinde-oss/kinde-typescript-sdk'
 import { computed } from 'vue'
 import { withQuery } from 'ufo'
-import apiRoutes from '#build/kinde-routes.config.mjs'
+import endpoints from '#build/kinde-routes.config.mjs'
 
 const props = defineProps<AuthURLOptions>()
 const href = computed(() => {
   const { authUrlParams, ..._authUrlParams } = props
-  return withQuery(apiRoutes.register, {
+  return withQuery(endpoints.register, {
     ...authUrlParams,
     ..._authUrlParams,
   })

--- a/src/runtime/components/RegisterLink.vue
+++ b/src/runtime/components/RegisterLink.vue
@@ -11,12 +11,12 @@
 import type { AuthURLOptions } from '@kinde-oss/kinde-typescript-sdk'
 import { computed } from 'vue'
 import { withQuery } from 'ufo'
-import { useRuntimeConfig } from '#app'
+import apiRoutes from '#build/kinde-routes.config.mjs'
 
 const props = defineProps<AuthURLOptions>()
 const href = computed(() => {
   const { authUrlParams, ..._authUrlParams } = props
-  return withQuery(useRuntimeConfig().kinde.apiRoutes.register || '/api/register', {
+  return withQuery(apiRoutes.register, {
     ...authUrlParams,
     ..._authUrlParams,
   })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
resolves #95 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Make the internal apiRoutes configurable. This can be useful if the default apiRoutes (e.g. `/api/login`) are already in use for some other purpose.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
