### PR TITLE
refactor: move `KindeContext` event declaration

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -178,6 +178,5 @@ export default defineNuxtModule<ModuleOptions>({
 declare module 'h3' {
   interface H3EventContext {
     kinde: KindeContext
-    test: string
   }
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -7,6 +7,7 @@ import type { CookieSerializeOptions } from 'cookie-es'
 import { join } from 'pathe'
 
 import { version } from '../package.json'
+import type { KindeContext } from './runtime/types'
 
 // Module options TypeScript interface definition
 export interface ModuleOptions {
@@ -173,3 +174,10 @@ export default defineNuxtModule<ModuleOptions>({
     })
   },
 })
+
+declare module 'h3' {
+  interface H3EventContext {
+    kinde: KindeContext
+    test: string
+  }
+}

--- a/src/runtime/server/middleware/kinde.ts
+++ b/src/runtime/server/middleware/kinde.ts
@@ -83,9 +83,3 @@ async function createSessionManager(event: H3Event): Promise<SessionManager> {
     },
   }
 }
-
-declare module 'h3' {
-  interface H3EventContext {
-    kinde: KindeContext
-  }
-}


### PR DESCRIPTION
### 🔗 Linked issue
resolves #150 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Module declaration inside the middleware wasn't picked up. Not sure if it is a bug in Nuxt, but it works if the declaration is moved to `module.ts`.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
