### PR TITLE
fix: fall back to logged-in status if no route rules present

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -159,7 +159,8 @@ export default defineNuxtModule<ModuleOptions>({
         || resolver.resolve('./runtime/server/api/portal.get'),
     })
 
-    if (nuxt.options.routeRules && Object.entries(nuxt.options.routeRules).some(([_, value]) => value.kinde)) {
+    const hasKindeRouteRules = Object.entries(nuxt.options.routeRules || {}).some(([_, value]) => value.kinde)
+    if (hasKindeRouteRules) {
       addServerHandler({
         route: options.endpoints!.access!,
         handler:
@@ -167,6 +168,10 @@ export default defineNuxtModule<ModuleOptions>({
           || resolver.resolve('./runtime/server/api/access.post'),
       })
     }
+    addTemplate({
+      filename: 'kinde-route-rules.mjs',
+      getContents: () => `export const hasKindeRouteRules = ${hasKindeRouteRules}`,
+    })
 
     // Composables
     addImports({ name: 'useAuth', as: 'useAuth', from: resolver.resolve('./runtime/composables') })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt-modules/kinde/issues/347

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this aims to fix a logic issue with the auth-logged-in middleware - previously:
- we always called `/api/access` even if this wasn't registered (b/c no route rules)
- we gave permission to access a route if there were _no_ route rules about it, when I think applying an `auth-logged-in` middleware should default to denying it if not logged in